### PR TITLE
Fixed "Bug": Re-Connect Test

### DIFF
--- a/connection_pool.js
+++ b/connection_pool.js
@@ -94,7 +94,6 @@ module.exports = {
               mcp.initiateConnection(options);
             }
           },
-
           disconnect: function() {
             this._instances -= 1;
             if (this._instances <= 0) {
@@ -104,7 +103,18 @@ module.exports = {
               util.log(`[mcprotocol] deleting connection from pool ~ ${id}`);
               delete pool[id];
             }
-          }
+          },
+          reinitialize: function() {
+            //in case of physical connection loss, it does not get the connection back
+            //when connecting again. the mcp object needs to be renewed. 
+            this.disconnect();
+            if (!mcp) {
+              mcp = new mcprotocol();
+              connecting = false;
+            }
+            this.connect();
+            this._instances += 1;
+          },
         };
 
         mcp.on("error", function(e) {

--- a/nodes/read.html
+++ b/nodes/read.html
@@ -127,7 +127,7 @@ SOFTWARE.
     <dd>The PLC connection</dd>
     <dt class="required">Address<span class="property-type">number | string | payload</span></dt>
     <dd>PLC Memory Address</dd>
-    <p><i>INFO: To open / close the MC Protocol connection, send boolean <code>true</code> in <code>msg.connect</code> or <code>msg.disconnect</code>.  Alternatively, send string <code>connect</code> or <code>disconnect</code> in <code>msg.topic</code> to the any mc read / mc write node.</i></p>
+    <p><i>INFO: To open / close the MC Protocol connection, send boolean <code>true</code> in <code>msg.connect</code> , <code>msg.disconnect</code> or <code>msg.reinitialize</code>.  Alternatively, send string <code>connect</code>, <code>disconnect</code> or <code>reinitialize</code> in <code>msg.topic</code> to the any mc read / mc write node.</i></p>
   </dl>
   <h3>Outputs</h3>
   <dl class="message-properties">

--- a/nodes/read.js
+++ b/nodes/read.js
@@ -217,6 +217,9 @@ module.exports = function(RED) {
         } else if (msg.connect === true || msg.topic === "connect") {
           this.connection.connect();
           return;
+        } else if (msg.reinitialize === true || msg.topic === "reinitialize") {
+          this.connection.reinitialize();
+          return; 
         }
 
         if (node.busy) return; //TODO: Consider queueing inputs?

--- a/nodes/write.html
+++ b/nodes/write.html
@@ -131,7 +131,7 @@ SOFTWARE.
     <dd>PLC Memory Address</dd>
     <dt class="required">Data<span class="property-type">Array&lt;number&gt; | number | string | payload </span></dt>
     <dd>Data to be written to PLC starting at specified address.</dd>
-    <p><i>INFO: To open / close the MC Protocol connection, send boolean <code>true</code> in <code>msg.connect</code> or <code>msg.disconnect</code>.  Alternatively, send string <code>connect</code> or <code>disconnect</code> in <code>msg.topic</code> to the any mc read / mc write node.</i></p>
+    <p><i>INFO: To open / close the MC Protocol connection, send boolean <code>true</code> in <code>msg.connect</code> , <code>msg.disconnect</code> or <code>msg.reinitialize</code>.  Alternatively, send string <code>connect</code>, <code>disconnect</code> or <code>reinitialize</code> in <code>msg.topic</code> to the any mc read / mc write node.</i></p>
   </dl>
   <h3>Outputs</h3>
   <dl class="message-properties">

--- a/nodes/write.js
+++ b/nodes/write.js
@@ -134,6 +134,9 @@ module.exports = function(RED) {
         } else if (msg.connect === true || msg.topic === "connect") {
           this.connection.connect();
           return;
+        } else if (msg.reinitialize === true || msg.topic === "reinitialize") {
+          this.connection.reinitialize();
+          return;
         }
 
         if (node.busy) return; //TODO: Consider queueing inputs?


### PR DESCRIPTION
We tested the nodes behaviour in  case of connection loss. Does it reconnect again?

Our Test scenario:

- reading cyclically data from a Q03UDE. (Only one test number: D100)
- disconnecting the cable or disabling the ethernet port via managed switch for >=1min.
- connecting again after >1min. 
- waiting for the node status (approx. 30-60sec) to change from "timeout" to "error".

Actions done:

- PLC power cycle does not bring the node back operational
- msg.connect or msg.disconnect && msg.connect does not bring the node back operational
- Deployment of the node in node-red --> **worked!**

We investigated thsi behaviour. It is related to the mcp object in connection_pool.js. Possibly with the net.js implementation. But a fixed could be to drop the connection, null the mcp oject and reinitalize it before connecting again.

Thanks for this great node. Feel free to pull this code to your project.

regards,
Chris